### PR TITLE
Fix sticky header in sponsor page

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -3,6 +3,8 @@ $landing-color-border: $color-hack-black-5;
 $landing-color-dark-bg: $color-hack-black-5;
 
 #index {
+  overflow-x: hidden;
+  
   .navbar {
     z-index: 2;
     height: 7rem;

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -20,11 +20,6 @@
   font-weight: bold;
 }
 
-html,
-body {
-  overflow-x: hidden;
-}
-
 em {
   color: $global-color-primary;
   font-style: normal;


### PR DESCRIPTION
Hotfixed the sticky headers!

Closes #47 

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/16010076/46770842-05078980-ccbf-11e8-8ede-ae7070ad9e2c.png">
