### PR TITLE
assign class to footer links

### DIFF
--- a/src/code-of-conduct.html
+++ b/src/code-of-conduct.html
@@ -170,9 +170,11 @@
 
   <footer class="footer">
     <ul class="footer__links">
-      <li><a href="/code-of-conduct">Code of Conduct</a></li>
-      <!-- <li><a href="">Press Kit</a></li>
-        <li><a href="">Privacy Policy</a></li> -->
+      <li>
+        <a class="navbar__nav-item navbar__link" href="/code-of-conduct">
+          Code of Conduct
+        </a>
+      </li>
     </ul>
     <ul class="footer__links-socials">
       <a class="footer__links-social footer__link" href="https://fb.com/mcgillhacks" target="_blank">

--- a/src/code-of-conduct.html
+++ b/src/code-of-conduct.html
@@ -171,7 +171,7 @@
   <footer class="footer">
     <ul class="footer__links">
       <li>
-        <a class="navbar__nav-item navbar__link" href="/code-of-conduct">
+        <a class="footer__link" href="/code-of-conduct">
           Code of Conduct
         </a>
       </li>

--- a/src/index.html
+++ b/src/index.html
@@ -65,7 +65,10 @@
 
 <body id="index">
   <!-- MLH Badge -->
-  <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:absolute;right:5rem;top:7rem;width:10%;z-index:10000" href="https://mlh.io/seasons/na-2019/events?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2019-season&utm_content=white" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2019/mlh-trust-badge-2019-white.svg" alt="Major League Hacking 2019 Hackathon Season" style="width:100%"></a>
+  <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:absolute;right:5rem;top:7rem;width:10%;z-index:10000"
+    href="https://mlh.io/seasons/na-2019/events?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2019-season&utm_content=white"
+    target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2019/mlh-trust-badge-2019-white.svg"
+      alt="Major League Hacking 2019 Hackathon Season" style="width:100%"></a>
   <!-- START FACEBOOK MESSENGER CHAT BOT CODE  -->
   <div id="fb-root"></div>
   <script>(function (d, s, id) {
@@ -304,9 +307,11 @@
   </section>
   <footer class="footer">
     <ul class="footer__links">
-      <li><a href="/code-of-conduct">Code of Conduct</a></li>
-      <!-- <li><a href="">Press Kit</a></li>
-      <li><a href="">Privacy Policy</a></li> -->
+      <li>
+        <a class="navbar__nav-item navbar__link" href="/code-of-conduct">
+          Code of Conduct
+        </a>
+      </li>
     </ul>
     <ul class="footer__links-socials">
       <a class="footer__links-social footer__link" href="https://fb.com/mcgillhacks" target="_blank">

--- a/src/index.html
+++ b/src/index.html
@@ -308,7 +308,7 @@
   <footer class="footer">
     <ul class="footer__links">
       <li>
-        <a class="navbar__nav-item navbar__link" href="/code-of-conduct">
+        <a class="footer__link" href="/code-of-conduct">
           Code of Conduct
         </a>
       </li>

--- a/src/sponsor.html
+++ b/src/sponsor.html
@@ -597,7 +597,7 @@
   <footer class="footer">
     <ul class="footer__links">
       <li>
-        <a class="navbar__nav-item navbar__link" href="/code-of-conduct">
+        <a class="footer__link" href="/code-of-conduct">
           Code of Conduct
         </a>
       </li>

--- a/src/sponsor.html
+++ b/src/sponsor.html
@@ -590,15 +590,17 @@
     </div>
   </section>
   <div class="get-in-touch">
-      <h2 class="get-in-touch__heading">want to learn more?</h2>
-      <h3 class="get-in-touch__subheading">get in touch with our team.</h3>
-      <a class="button button-primary" href="mailto:sponsor@mchacks.ca" target="_blank">EMAIL US</a>
-    </div>
+    <h2 class="get-in-touch__heading">want to learn more?</h2>
+    <h3 class="get-in-touch__subheading">get in touch with our team.</h3>
+    <a class="button button-primary" href="mailto:sponsor@mchacks.ca" target="_blank">EMAIL US</a>
+  </div>
   <footer class="footer">
     <ul class="footer__links">
-      <li><a href="/code-of-conduct">Code of Conduct</a></li>
-      <!-- <li><a href="">Press Kit</a></li>
-        <li><a href="">Privacy Policy</a></li> -->
+      <li>
+        <a class="navbar__nav-item navbar__link" href="/code-of-conduct">
+          Code of Conduct
+        </a>
+      </li>
     </ul>
     <ul class="footer__links-socials">
       <a class="footer__links-social footer__link" href="https://fb.com/mcgillhacks" target="_blank">

--- a/src/style/nav.scss
+++ b/src/style/nav.scss
@@ -1,3 +1,5 @@
+$navbar-link: $color-hack-black-60;
+
 .navbar {
   z-index: 2;
   height: 7rem;
@@ -40,7 +42,7 @@
 }
 
 .navbar__link {
-  color: $color-hack-black-60;
+  color: $navbar-link;
 
   &:focus,
   &:hover {
@@ -81,7 +83,7 @@
 }
 
 .footer__link {
-  color: $color-hack-black-60;
+  color: $navbar-link;
 
   &:focus,
   &:hover {


### PR DESCRIPTION
Footer links were not the same hex as nav links because class wasn’t assigned in html. Updated all pages so they’re the same hex now.

Before:
![image](https://user-images.githubusercontent.com/23108291/47941448-93d58380-dec4-11e8-96b8-9e4239a0eb09.png)
![image](https://user-images.githubusercontent.com/23108291/47941451-959f4700-dec4-11e8-9aa9-96bbcc803e93.png)
