### PR TITLE
Small fixes to landing page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -338,8 +338,7 @@
             <div class="accordion__item">
               <a class="accordion__title">What if I don't have a team or idea?</a>
               <div class="accordion__content">
-                <p>Not a problem! We'll have team-forming activities to help you find teammates and workshops to
-                  brainstorm ideas for our verticals.</p>
+                <p>Not a problem! We'll have team-forming activities to help you find teammates and brainstorm ideas. There'll also be workshops to learn technologies that could spark an idea to hack on.</p>
               </div>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -173,7 +173,7 @@
           North America come together for a weekend of beginner-to-pro workshops, decked-out hardware, delicious food,
           and
           some epic hacking.
-
+          <br><br>
           Whether you're writing your first line of code, playing around with APIs, or building the next
           blockchain, McHacks
           has everything setup for your next big hack. We hope you'll join us this Winter as we jump into round 6 of

--- a/src/index.html
+++ b/src/index.html
@@ -92,11 +92,11 @@
       <a class="navbar__nav-item navbar__link" href="#about">
         About
       </a>
-      <a class="navbar__nav-item navbar__link" href="#sponsor">
-        Sponsors
-      </a>
       <a class="navbar__nav-item navbar__link" href="#faq">
         FAQ
+      </a>
+      <a class="navbar__nav-item navbar__link" href="#sponsor">
+        Sponsors
       </a>
       <a class="navbar__nav-item navbar__link" href="https://2018.mchacks.ca" target="_blank">
         2018
@@ -183,6 +183,82 @@
       </div>
       <div class="one-half column">
         <img class="intro__image" src="static/info-picture.jpg" />
+      </div>
+    </div>
+  </section>
+  <section class="faq faq__wrapper">
+    <div class="faq__container">
+      <div class="faq_jump-to" id='faq'></div>
+      <h2> Frequently Asked Questions</h2>
+      <div class="faq__flex-container">
+        <div class="faq__left-column">
+          <div class="accordion">
+            <div class="accordion__item">
+              <a class="accordion__title">What is a hackathon?</a>
+              <div class="accordion__content">
+                <p>A hackathon is a coding event where participants (hackers) spend 24 hours working in teams of 1-4
+                  people to build and code projects (hacks). Bring your ideas and we'll give you everything you need to
+                  bring it to life.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">What should I bring?</a>
+              <div class="accordion__content">
+                <p>You should bring your student ID and anything you’d need for a productive, healthy, and fun weekend:
+                  laptop, phone, chargers, deodorant (!), change of clothes, etc. Don't worry about food and drinks,
+                  we've got you covered there.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">How will I get to McHacks?</a>
+              <div class="accordion__content">
+                <p>We'll be sending a number of buses to nearby cities to get you to and from McHacks. We'll also have
+                  travel reimbursements available on a case-by-case basis.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">What if I don't have a team or idea?</a>
+              <div class="accordion__content">
+                <p>Not a problem! We'll have team-forming activities to help you find teammates and workshops to
+                  brainstorm ideas for our verticals.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="faq__right-column">
+          <div class="accordion">
+            <div class="accordion__item">
+              <a class="accordion__title">Who can participate?</a>
+              <div class="accordion__content">
+                <p>Students at high school, CEGEP, and undergraduate levels are welcome to apply to McHacks! If you're
+                  under 18, we'll need a parental consent form.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">How much does it cost to attend?</a>
+              <div class="accordion__content">
+                <p>Absolutely nothing! Admission is free, and includes food and drinks, snacks, workshops, (lots of)
+                  swag, and and epic weekend!</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">What if I don't know how to code?</a>
+              <div class="accordion__content">
+                <p>With beginner-friendly workshops, mentors around the clock, and friendly hackers around you, McHacks
+                  is the perfect place to push your first line of code! We'll have everything to help you build
+                  something you're proud of!</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">I don't see my question here...</a>
+              <div class="accordion__content">
+                <p>If you've got something else on your mind, message us on <a href="https://facebook.com/mcgillhacks"
+                    target="_blank">Facebook
+                  </a> or shoot us an email at <a href="mailto:contact@mchacks.ca" target="_blank">contact@mchacks.ca</a>.</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -302,82 +378,6 @@
         <a href="https://www.wolframalpha.com/" target="_blank">
           <img class="sponsor-list__logo" src="static/sponsors/wolfram.png" />
         </a>
-      </div>
-    </div>
-  </section>
-  <section class="faq faq__wrapper">
-    <div class="faq__container">
-      <div class="faq_jump-to" id='faq'></div>
-      <h2> Frequently Asked Questions</h2>
-      <div class="faq__flex-container">
-        <div class="faq__left-column">
-          <div class="accordion">
-            <div class="accordion__item">
-              <a class="accordion__title">What is a hackathon?</a>
-              <div class="accordion__content">
-                <p>A hackathon is a coding event where participants (hackers) spend 24 hours working in teams of 1-4
-                  people to build and code projects (hacks). Bring your ideas and we'll give you everything you need to
-                  bring it to life.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">What should I bring?</a>
-              <div class="accordion__content">
-                <p>You should bring your student ID and anything you’d need for a productive, healthy, and fun weekend:
-                  laptop, phone, chargers, deodorant (!), change of clothes, etc. Don't worry about food and drinks,
-                  we've got you covered there.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">How will I get to McHacks?</a>
-              <div class="accordion__content">
-                <p>We'll be sending a number of buses to nearby cities to get you to and from McHacks. We'll also have
-                  travel reimbursements available on a case-by-case basis.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">What if I don't have a team or idea?</a>
-              <div class="accordion__content">
-                <p>Not a problem! We'll have team-forming activities to help you find teammates and workshops to
-                  brainstorm ideas for our verticals.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="faq__right-column">
-          <div class="accordion">
-            <div class="accordion__item">
-              <a class="accordion__title">Who can participate?</a>
-              <div class="accordion__content">
-                <p>Students at high school, CEGEP, and undergraduate levels are welcome to apply to McHacks! If you're
-                  under 18, we'll need a parental consent form.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">How much does it cost to attend?</a>
-              <div class="accordion__content">
-                <p>Absolutely nothing! Admission is free, and includes food and drinks, snacks, workshops, (lots of)
-                  swag, and and epic weekend!</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">What if I don't know how to code?</a>
-              <div class="accordion__content">
-                <p>With beginner-friendly workshops, mentors around the clock, and friendly hackers around you, McHacks
-                  is the perfect place to push your first line of code! We'll have everything to help you build
-                  something you're proud of!</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">I don't see my question here...</a>
-              <div class="accordion__content">
-                <p>If you've got something else on your mind, message us on <a href="https://facebook.com/mcgillhacks"
-                    target="_blank">Facebook
-                  </a> or shoot us an email at <a href="mailto:contact@mchacks.ca" target="_blank">contact@mchacks.ca</a>.</p>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </section>

--- a/src/index.html
+++ b/src/index.html
@@ -92,11 +92,11 @@
       <a class="navbar__nav-item navbar__link" href="#about">
         About
       </a>
-      <a class="navbar__nav-item navbar__link" href="#faq">
-        FAQ
-      </a>
       <a class="navbar__nav-item navbar__link" href="#sponsor">
         Sponsors
+      </a>
+      <a class="navbar__nav-item navbar__link" href="#faq">
+        FAQ
       </a>
       <a class="navbar__nav-item navbar__link" href="https://2018.mchacks.ca" target="_blank">
         2018
@@ -183,82 +183,6 @@
       </div>
       <div class="one-half column">
         <img class="intro__image" src="static/info-picture.jpg" />
-      </div>
-    </div>
-  </section>
-  <section class="faq faq__wrapper">
-    <div class="faq__container">
-      <div class="faq_jump-to" id='faq'></div>
-      <h2> Frequently Asked Questions</h2>
-      <div class="faq__flex-container">
-        <div class="faq__left-column">
-          <div class="accordion">
-            <div class="accordion__item">
-              <a class="accordion__title">What is a hackathon?</a>
-              <div class="accordion__content">
-                <p>A hackathon is a coding event where participants (hackers) spend 24 hours working in teams of 1-4
-                  people to build and code projects (hacks). Bring your ideas and we'll give you everything you need to
-                  bring it to life.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">What should I bring?</a>
-              <div class="accordion__content">
-                <p>You should bring your student ID and anything you’d need for a productive, healthy, and fun weekend:
-                  laptop, phone, chargers, deodorant (!), change of clothes, etc. Don't worry about food and drinks,
-                  we've got you covered there.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">How will I get to McHacks?</a>
-              <div class="accordion__content">
-                <p>We'll be sending a number of buses to nearby cities to get you to and from McHacks. We'll also have
-                  travel reimbursements available on a case-by-case basis.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">What if I don't have a team or idea?</a>
-              <div class="accordion__content">
-                <p>Not a problem! We'll have team-forming activities to help you find teammates and workshops to
-                  brainstorm ideas for our verticals.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="faq__right-column">
-          <div class="accordion">
-            <div class="accordion__item">
-              <a class="accordion__title">Who can participate?</a>
-              <div class="accordion__content">
-                <p>Students at high school, CEGEP, and undergraduate levels are welcome to apply to McHacks! If you're
-                  under 18, we'll need a parental consent form.</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">How much does it cost to attend?</a>
-              <div class="accordion__content">
-                <p>Absolutely nothing! Admission is free, and includes food and drinks, snacks, workshops, (lots of)
-                  swag, and and epic weekend!</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">What if I don't know how to code?</a>
-              <div class="accordion__content">
-                <p>With beginner-friendly workshops, mentors around the clock, and friendly hackers around you, McHacks
-                  is the perfect place to push your first line of code! We'll have everything to help you build
-                  something you're proud of!</p>
-              </div>
-            </div>
-            <div class="accordion__item">
-              <a class="accordion__title">I don't see my question here...</a>
-              <div class="accordion__content">
-                <p>If you've got something else on your mind, message us on <a href="https://facebook.com/mcgillhacks"
-                    target="_blank">Facebook
-                  </a> or shoot us an email at <a href="mailto:contact@mchacks.ca" target="_blank">contact@mchacks.ca</a>.</p>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </section>
@@ -378,6 +302,82 @@
         <a href="https://www.wolframalpha.com/" target="_blank">
           <img class="sponsor-list__logo" src="static/sponsors/wolfram.png" />
         </a>
+      </div>
+    </div>
+  </section>
+  <section class="faq faq__wrapper">
+    <div class="faq__container">
+      <div class="faq_jump-to" id='faq'></div>
+      <h2> Frequently Asked Questions</h2>
+      <div class="faq__flex-container">
+        <div class="faq__left-column">
+          <div class="accordion">
+            <div class="accordion__item">
+              <a class="accordion__title">What is a hackathon?</a>
+              <div class="accordion__content">
+                <p>A hackathon is a coding event where participants (hackers) spend 24 hours working in teams of 1-4
+                  people to build and code projects (hacks). Bring your ideas and we'll give you everything you need to
+                  bring it to life.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">What should I bring?</a>
+              <div class="accordion__content">
+                <p>You should bring your student ID and anything you’d need for a productive, healthy, and fun weekend:
+                  laptop, phone, chargers, deodorant (!), change of clothes, etc. Don't worry about food and drinks,
+                  we've got you covered there.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">How will I get to McHacks?</a>
+              <div class="accordion__content">
+                <p>We'll be sending a number of buses to nearby cities to get you to and from McHacks. We'll also have
+                  travel reimbursements available on a case-by-case basis.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">What if I don't have a team or idea?</a>
+              <div class="accordion__content">
+                <p>Not a problem! We'll have team-forming activities to help you find teammates and workshops to
+                  brainstorm ideas for our verticals.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="faq__right-column">
+          <div class="accordion">
+            <div class="accordion__item">
+              <a class="accordion__title">Who can participate?</a>
+              <div class="accordion__content">
+                <p>Students at high school, CEGEP, and undergraduate levels are welcome to apply to McHacks! If you're
+                  under 18, we'll need a parental consent form.</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">How much does it cost to attend?</a>
+              <div class="accordion__content">
+                <p>Absolutely nothing! Admission is free, and includes food and drinks, snacks, workshops, (lots of)
+                  swag, and and epic weekend!</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">What if I don't know how to code?</a>
+              <div class="accordion__content">
+                <p>With beginner-friendly workshops, mentors around the clock, and friendly hackers around you, McHacks
+                  is the perfect place to push your first line of code! We'll have everything to help you build
+                  something you're proud of!</p>
+              </div>
+            </div>
+            <div class="accordion__item">
+              <a class="accordion__title">I don't see my question here...</a>
+              <div class="accordion__content">
+                <p>If you've got something else on your mind, message us on <a href="https://facebook.com/mcgillhacks"
+                    target="_blank">Facebook
+                  </a> or shoot us an email at <a href="mailto:contact@mchacks.ca" target="_blank">contact@mchacks.ca</a>.</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -259,14 +259,15 @@ $landing-color-dark-bg: $color-hack-black-5;
   }
 
   .faq__container {
-    padding-bottom: 60rem;
+    padding-top: 20rem;
     max-width: 88rem;
-    height: 40rem;
+    height: 48rem;
     text-align: center;
     margin: auto;
 
     @include media-query($md-up) {
-      padding-bottom: 32rem;
+      padding-top: 48rem;
+      height: 20rem;
     }
   }
 

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -333,7 +333,7 @@ $landing-color-dark-bg: $color-hack-black-5;
     border-radius: 4px;
     margin-bottom: 3rem;
     position: relative;
-    z-index: 2;
+    z-index: 1;
 
     &:after {
       font-weight: 900;

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -259,15 +259,14 @@ $landing-color-dark-bg: $color-hack-black-5;
   }
 
   .faq__container {
-    padding-top: 20rem;
+    padding-bottom: 60rem;
     max-width: 88rem;
-    height: 48rem;
+    height: 40rem;
     text-align: center;
     margin: auto;
 
     @include media-query($md-up) {
-      padding-top: 48rem;
-      height: 20rem;
+      padding-bottom: 32rem;
     }
   }
 

--- a/src/style/nav.scss
+++ b/src/style/nav.scss
@@ -12,7 +12,7 @@ $navbar-link: $color-hack-black-60;
 
 .navbar__brand {
   display: inline-block;
-  padding: 1rem 0 1.4rem 1.4rem;
+  padding: 1.2rem 0 1.2rem 1.4rem;
   margin-left: 1.2rem;
 
   &:focus,


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
I fixed the padding on the martlet again. `padding-bottom` wasn't working because of other styling so I adjusted `padding-top` to complement better.

~~Per design team, moved `#faq` above `#sponsor` and adjusted padding so visual divider isn't hiding the FAQ and for other visuals they're working. I also added some adjustments to padding for the FAQ section since it's now below the divider instead of accordion items showing up on top but copy underneath.~~

### Does this close any currently open issues? 

### Any relevant logs, error output, etc?

### Any other comments?

### Where has this been tested?
**Platforms (Desktop, Phone, Tablet, etc...)**
MacOS

**Browsers**
Chrome, Firefox