### PR TITLE
Fix faq typo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -413,7 +413,7 @@
               <a class="accordion__title">How much does it cost to attend?</a>
               <div class="accordion__content">
                 <p>Absolutely nothing! Admission is free, and includes food and drinks, snacks, workshops, (lots of)
-                  swag, and and epic weekend!</p>
+                  swag, and an epic weekend!</p>
               </div>
             </div>
             <div class="accordion__item">


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Edit typo from `and and` to `and an`

![image](https://user-images.githubusercontent.com/23108291/49693875-e140b280-fb4c-11e8-8675-3191e973bf55.png)


### Does this close any currently open issues? 

### Any relevant logs, error output, etc?

### Any other comments?

### Where has this been tested?
**Platforms (Desktop, Phone, Tablet, etc...)**

**Browsers**
