### PR TITLE
Move chat bot to not block footer

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -476,3 +476,11 @@ $landing-color-dark-bg: $color-hack-black-5;
 
   /*--  //FAQ-SECTION  --*/
 }
+
+.fb_dialog.fb_dialog_advanced.fb_customer_chat_bubble_animated_no_badge.fb_customer_chat_bubble_pop_in {
+  margin-bottom: 100px !important;
+
+  @include media-query($sm-up) {
+    margin-bottom: 80px !important;
+  }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Played around with Chrome Dev Tools to move the FB chat bot up so it doesn't block the footer links. The dialog box now covers the button but tbh this > covering footer.

A pretty jank fix if it works but 🤷‍♀️ 

### Does this close any currently open issues? 

#57 

### Any relevant logs, error output, etc?

### Any other comments?

If all goes well, it should look like this:

![2018-12-13 01 13 33](https://user-images.githubusercontent.com/23108291/49919381-5de8cf00-fe74-11e8-87b5-a7a847bd8a2a.gif)

### Where has this been tested?
**Platforms (Desktop, Phone, Tablet, etc...)**
Mac

**Browsers**
Chrome