### PR TITLE
chore: remove phone numbers from code of conduct

### DIFF
--- a/src/code-of-conduct.html
+++ b/src/code-of-conduct.html
@@ -166,11 +166,7 @@
     <p>If you feel uncomfortable or think there may be a potential violation of the code of conduct, please report it
       through the following methods. All reporters have the right to remain anonymous.</p>
     <p>Please also don’t hesitate to contact any of the organizers or the security guard on duty at any time. You can
-      get in direct touch with the Co-Directors below:</p>
-    <ul>
-      <li>Kyle Rubenok (647) 500-8391</li>
-      <li>Loreina Chew (647) 823-7087</li>
-    </ul>
+      get in direct touch with the Co-Directors below.</p>
     <p>You can also email us at <a href="mailto:directors@mchacks.ca">directors@mchacks.ca</a>.</p>
     <p>If you are uncomfortable reporting a potential violation to the Co-Directors for any reason, please approach the
       contracted security personnel or MLH Coaches (phone number below) on hand for assistance. </p>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Removing me and Kyle's phone numbers from the code of conduct page. It's been cached and shows up on search engines, so I want to remove that for _safety_ reasons.

### Does this close any currently open issues? 

### Any relevant logs, error output, etc?

### Any other comments?

### Where has this been tested?
**Platforms (Desktop, Phone, Tablet, etc...)**

**Browsers**
